### PR TITLE
Fix bug when parsing arguments for ListWardPatientsCommand.

### DIFF
--- a/src/main/java/seedu/patientist/logic/commands/ListWardPatientsCommand.java
+++ b/src/main/java/seedu/patientist/logic/commands/ListWardPatientsCommand.java
@@ -13,22 +13,29 @@ import seedu.patientist.model.person.patient.PatientInWardPredicate;
 public class ListWardPatientsCommand extends Command {
     public static final String COMMAND_WORD = "lswardpat";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": List all patients in ward __\n"
-            + "Example: " + COMMAND_WORD + " Block2WardA\n"
-            + "Alice Peter John";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose wards matches any of "
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " Block1WardA Block2WardC";
 
-    private final String wardToBeChecked;
+    private final PatientInWardPredicate predicate;
 
-    public ListWardPatientsCommand(String ward) {
-        wardToBeChecked = ward;
+    public ListWardPatientsCommand(PatientInWardPredicate predicate) {
+        this.predicate = predicate;
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredPersonList(new PatientInWardPredicate(wardToBeChecked));
+        model.updateFilteredPersonList(predicate);
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
     }
 
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+               || (other instanceof ListWardPatientsCommand // instanceof handles nulls
+                   && predicate.equals(((ListWardPatientsCommand) other).predicate));
+    }
 }

--- a/src/main/java/seedu/patientist/logic/commands/ListWardPatientsCommand.java
+++ b/src/main/java/seedu/patientist/logic/commands/ListWardPatientsCommand.java
@@ -15,6 +15,7 @@ public class ListWardPatientsCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose wards matches any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Keywords must be alphanumeric.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " Block1WardA Block2WardC";
 

--- a/src/main/java/seedu/patientist/logic/parser/ListWardPatientsCommandParser.java
+++ b/src/main/java/seedu/patientist/logic/parser/ListWardPatientsCommandParser.java
@@ -1,0 +1,32 @@
+package seedu.patientist.logic.parser;
+
+import static seedu.patientist.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+
+import seedu.patientist.logic.commands.ListWardPatientsCommand;
+import seedu.patientist.logic.parser.exceptions.ParseException;
+import seedu.patientist.model.person.patient.PatientInWardPredicate;
+
+/**
+ * Finds and lists all patients in patientist book whose ward contains any of the argument keywords.
+ * Keyword matching is case insensitive.
+ */
+public class ListWardPatientsCommandParser implements Parser<ListWardPatientsCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindCommand
+     * and returns a FindCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ListWardPatientsCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListWardPatientsCommand.MESSAGE_USAGE));
+        }
+
+        String[] wardKeywords = trimmedArgs.split("\\s+");
+
+        return new ListWardPatientsCommand(new PatientInWardPredicate(Arrays.asList(wardKeywords)));
+    }
+}

--- a/src/main/java/seedu/patientist/logic/parser/ListWardPatientsCommandParser.java
+++ b/src/main/java/seedu/patientist/logic/parser/ListWardPatientsCommandParser.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import seedu.patientist.logic.commands.ListWardPatientsCommand;
 import seedu.patientist.logic.parser.exceptions.ParseException;
 import seedu.patientist.model.person.patient.PatientInWardPredicate;
+import seedu.patientist.model.tag.Tag;
 
 /**
  * Finds and lists all patients in patientist book whose ward contains any of the argument keywords.
@@ -26,6 +27,12 @@ public class ListWardPatientsCommandParser implements Parser<ListWardPatientsCom
         }
 
         String[] wardKeywords = trimmedArgs.split("\\s+");
+        for (String keyword : wardKeywords) {
+            if (!keyword.matches(Tag.VALIDATION_REGEX)) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListWardPatientsCommand.MESSAGE_USAGE));
+            }
+        }
 
         return new ListWardPatientsCommand(new PatientInWardPredicate(Arrays.asList(wardKeywords)));
     }

--- a/src/main/java/seedu/patientist/logic/parser/PatientistParser.java
+++ b/src/main/java/seedu/patientist/logic/parser/PatientistParser.java
@@ -84,7 +84,7 @@ public class PatientistParser {
             return new ListPatientsCommand();
 
         case ListWardPatientsCommand.COMMAND_WORD:
-            return new ListWardPatientsCommand(arguments);
+            return new ListWardPatientsCommandParser().parse(arguments);
 
         case ListStaffCommand.COMMAND_WORD:
             return new ListStaffCommand();

--- a/src/main/java/seedu/patientist/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/patientist/logic/parser/ViewCommandParser.java
@@ -3,7 +3,6 @@ package seedu.patientist.logic.parser;
 import static seedu.patientist.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.patientist.commons.core.index.Index;
-import seedu.patientist.logic.commands.DeleteCommand;
 import seedu.patientist.logic.commands.ViewCommand;
 import seedu.patientist.logic.parser.exceptions.ParseException;
 
@@ -23,7 +22,7 @@ public class ViewCommandParser implements Parser<ViewCommand> {
             return new ViewCommand(index);
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE), pe);
         }
     }
 

--- a/src/main/java/seedu/patientist/model/person/patient/PatientInWardPredicate.java
+++ b/src/main/java/seedu/patientist/model/person/patient/PatientInWardPredicate.java
@@ -1,5 +1,6 @@
 package seedu.patientist.model.person.patient;
 
+import java.util.List;
 import java.util.function.Predicate;
 
 import seedu.patientist.model.person.Person;
@@ -9,21 +10,22 @@ import seedu.patientist.model.tag.Tag;
  * Checks the tag of all personnel to see if they belong to a particular ward
  */
 public class PatientInWardPredicate implements Predicate<Person> {
-    private final Tag ward;
+    private final List<String> keywords;
 
-    public PatientInWardPredicate(String ward1) {
-        ward = new Tag(ward1);
+    public PatientInWardPredicate(List<String> keywords) {
+        this.keywords = keywords;
     }
 
     @Override
     public boolean test(Person person) {
-        return person.getTags().contains(ward);
+        return keywords.stream()
+                .anyMatch(keyword -> person.getTags().contains(new Tag(keyword)));
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof PatientInWardPredicate); // instanceof handles nulls
-
+                || (other instanceof PatientInWardPredicate // instanceof handles nulls
+                && keywords.equals(((PatientInWardPredicate) other).keywords));
     }
 }

--- a/src/test/java/seedu/patientist/logic/commands/ListWardPatientCommandTest.java
+++ b/src/test/java/seedu/patientist/logic/commands/ListWardPatientCommandTest.java
@@ -1,12 +1,16 @@
 package seedu.patientist.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.patientist.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.patientist.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.patientist.testutil.TypicalPatients.ADAM;
 import static seedu.patientist.testutil.TypicalPatients.CHARLIE;
 import static seedu.patientist.testutil.TypicalPatients.getTypicalPatientist;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
@@ -19,15 +23,67 @@ public class ListWardPatientCommandTest {
     private Model model = new ModelManager(getTypicalPatientist(), new UserPrefs());
     private Model expectedModel = new ModelManager(getTypicalPatientist(), new UserPrefs());
 
+    @Test
+    public void equals() {
+        PatientInWardPredicate firstPredicate =
+                new PatientInWardPredicate(Collections.singletonList("first"));
+        PatientInWardPredicate secondPredicate =
+                new PatientInWardPredicate(Collections.singletonList("second"));
+
+        ListWardPatientsCommand findFirstCommand = new ListWardPatientsCommand(firstPredicate);
+        ListWardPatientsCommand findSecondCommand = new ListWardPatientsCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(findFirstCommand.equals(findFirstCommand));
+
+        // same values -> returns true
+        ListWardPatientsCommand findFirstCommandCopy = new ListWardPatientsCommand(firstPredicate);
+        assertTrue(findFirstCommand.equals(findFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(findFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(findFirstCommand.equals(null));
+
+        // different ward -> returns false
+        assertFalse(findFirstCommand.equals(findSecondCommand));
+    }
+
+    @Test
+    public void execute_zeroKeywords_noPatientFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        PatientInWardPredicate predicate = preparePredicate(" ");
+        ListWardPatientsCommand command = new ListWardPatientsCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleKeywords_multiplePersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
+        PatientInWardPredicate predicate = preparePredicate("Block1WardA Block2WardC Block2WardA");
+        ListWardPatientsCommand command = new ListWardPatientsCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ADAM, CHARLIE), model.getFilteredPersonList());
+    }
 
     @Test
     public void execute_onlyPatients_found() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
-        PatientInWardPredicate predicate = new PatientInWardPredicate("Block2WardA");
-        ListWardPatientsCommand command = new ListWardPatientsCommand("Block2WardA");
+        PatientInWardPredicate predicate = new PatientInWardPredicate(Collections.singletonList("Block2WardA"));
+        ListWardPatientsCommand command = new ListWardPatientsCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CHARLIE), model.getFilteredPersonList());
     }
 
+    /**
+     * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
+     */
+    private PatientInWardPredicate preparePredicate(String userInput) {
+        return new PatientInWardPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
 }

--- a/src/test/java/seedu/patientist/logic/commands/ViewCommandTest.java
+++ b/src/test/java/seedu/patientist/logic/commands/ViewCommandTest.java
@@ -1,0 +1,98 @@
+package seedu.patientist.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.patientist.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.patientist.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.patientist.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.patientist.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.patientist.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.patientist.testutil.TypicalPersons.getTypicalPatientist;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.patientist.commons.core.Messages;
+import seedu.patientist.commons.core.index.Index;
+import seedu.patientist.model.Model;
+import seedu.patientist.model.ModelManager;
+import seedu.patientist.model.UserPrefs;
+import seedu.patientist.model.person.Person;
+
+
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code ViewCommand}.
+ */
+public class ViewCommandTest {
+    private Model model = new ModelManager(getTypicalPatientist(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Person personToView = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        ViewCommand viewCommand = new ViewCommand(INDEX_FIRST_PERSON);
+
+        String expectedMessage = String.format(ViewCommand.MESSAGE_VIEW_PERSON_SUCCESS, personToView);
+
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, 0, false, false);
+
+        assertCommandSuccess(viewCommand, model, expectedCommandResult, model);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        ViewCommand viewCommand = new ViewCommand(outOfBoundIndex);
+
+        assertCommandFailure(viewCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Person personToView = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        ViewCommand viewCommand = new ViewCommand(INDEX_FIRST_PERSON);
+
+        String expectedMessage = String.format(ViewCommand.MESSAGE_VIEW_PERSON_SUCCESS, personToView);
+
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, 0, false, false);
+
+        assertCommandSuccess(viewCommand, model, expectedCommandResult, model);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        // ensures that outOfBoundIndex is still in bounds of patientist book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getPatientist().getPersonList().size());
+
+        ViewCommand viewCommand = new ViewCommand(outOfBoundIndex);
+
+        assertCommandFailure(viewCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        ViewCommand viewFirstCommand = new ViewCommand(INDEX_FIRST_PERSON);
+        ViewCommand viewSecondCommand = new ViewCommand(INDEX_SECOND_PERSON);
+
+        // same object -> returns true
+        assertTrue(viewFirstCommand.equals(viewFirstCommand));
+
+        // same values -> returns true
+        ViewCommand viewFirstCommandCopy = new ViewCommand(INDEX_FIRST_PERSON);
+        assertTrue(viewFirstCommand.equals(viewFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(viewFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(viewFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(viewFirstCommand.equals(viewSecondCommand));
+    }
+}

--- a/src/test/java/seedu/patientist/logic/parser/ListWardPatientsCommandParserTest.java
+++ b/src/test/java/seedu/patientist/logic/parser/ListWardPatientsCommandParserTest.java
@@ -1,0 +1,33 @@
+package seedu.patientist.logic.parser;
+
+import static seedu.patientist.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.patientist.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.patientist.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.patientist.logic.commands.ListWardPatientsCommand;
+import seedu.patientist.model.person.patient.PatientInWardPredicate;
+
+public class ListWardPatientsCommandParserTest {
+    private ListWardPatientsCommandParser parser = new ListWardPatientsCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListWardPatientsCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsFindCommand() {
+        // no leading and trailing whitespaces
+        ListWardPatientsCommand expectedFindCommand =
+                new ListWardPatientsCommand(new PatientInWardPredicate(Arrays.asList("Alice", "Bob")));
+        assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+    }
+}

--- a/src/test/java/seedu/patientist/logic/parser/ViewCommandParserTest.java
+++ b/src/test/java/seedu/patientist/logic/parser/ViewCommandParserTest.java
@@ -1,0 +1,24 @@
+package seedu.patientist.logic.parser;
+
+import static seedu.patientist.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.patientist.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.patientist.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.patientist.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.patientist.logic.commands.ViewCommand;
+
+public class ViewCommandParserTest {
+    private ViewCommandParser parser = new ViewCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsDeleteCommand() {
+        assertParseSuccess(parser, "1", new ViewCommand(INDEX_FIRST_PERSON));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
+    }
+}


### PR DESCRIPTION
- Added a parser to parse arguments before passing into ListWardPatientsCommand.
- Fixed bug where arguments were not trimmed before passing into ListWardPatientsCommand.
- Update ListWardPatientCommand and PatientInWardPredicate to handle multiple keywords.
- Added new tests for ListWardPatientsCommand, ListWardPatientsCommandParser, ViewCommand and ViewCommandParser.

This will address #81 